### PR TITLE
Added option to disable selection/deselection

### DIFF
--- a/FSCalendar/FSCalendar.h
+++ b/FSCalendar/FSCalendar.h
@@ -79,6 +79,7 @@ IB_DESIGNABLE
 
 @property (assign, nonatomic) FSCalendarScrollDirection scrollDirection;
 @property (assign, nonatomic) FSCalendarScope scope;
+@property (assign, nonatomic) BOOL disableSelection;
 @property (assign, nonatomic) IBInspectable NSUInteger firstWeekday;
 @property (assign, nonatomic) IBInspectable CGFloat headerHeight;
 @property (assign, nonatomic) IBInspectable BOOL allowsMultipleSelection;

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -131,6 +131,7 @@ static BOOL FSCalendarInInterfaceBuilder = NO;
     
     _needsAdjustingViewFrame = YES;
     _needsAdjustingTextSize = YES;
+    _disableSelection = NO;
     
     UIView *contentView = [[UIView alloc] initWithFrame:CGRectZero];
     contentView.backgroundColor = [UIColor clearColor];
@@ -434,6 +435,9 @@ static BOOL FSCalendarInInterfaceBuilder = NO;
 
 - (BOOL)collectionView:(UICollectionView *)collectionView shouldSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
+    if (_disableSelection) {
+        return NO;
+    }
     FSCalendarCell *cell = (FSCalendarCell *)[collectionView cellForItemAtIndexPath:indexPath];
     if (cell.dateIsPlaceholder) {
         if ([self isDateInRange:cell.date]) {
@@ -452,6 +456,10 @@ static BOOL FSCalendarInInterfaceBuilder = NO;
         shouldSelect &= [self shouldSelectDate:cell.date];
     }
     return shouldSelect && [self isDateInRange:cell.date];
+}
+
+- (BOOL)collectionView:(UICollectionView *)collectionView shouldDeselectItemAtIndexPath:(NSIndexPath *)indexPath {
+    return !_disableSelection;
 }
 
 - (void)collectionView:(UICollectionView *)collectionView didDeselectItemAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
Added a Boolean value, disableSelection, that allows for the calendar to be read only. Developers should set the dates they want to appear as selected, and then set disableSelection as YES to disable.