### PR TITLE
Provide functionality to change the title and background color for each date

### DIFF
--- a/FSCalendar/FSCalendar.h
+++ b/FSCalendar/FSCalendar.h
@@ -63,6 +63,8 @@ typedef NS_ENUM(NSInteger, FSCalendarCellState) {
 @optional
 - (NSString *)calendar:(FSCalendar *)calendar subtitleForDate:(NSDate *)date;
 - (UIImage *)calendar:(FSCalendar *)calendar imageForDate:(NSDate *)date;
+- (UIColor *)calendar:(FSCalendar *)calendar backgroundColorForDate:(NSDate *)date;
+- (UIColor *)calendar:(FSCalendar *)calendar titleLabelColorForDate:(NSDate *)date;
 - (BOOL)calendar:(FSCalendar *)calendar hasEventForDate:(NSDate *)date;
 - (NSDate *)minimumDateForCalendar:(FSCalendar *)calendar;
 - (NSDate *)maximumDateForCalendar:(FSCalendar *)calendar;

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -23,6 +23,8 @@
 
 - (BOOL)hasEventForDate:(NSDate *)date;
 - (NSString *)subtitleForDate:(NSDate *)date;
+- (UIColor *)backgroundColorForDate:(NSDate*)date;
+- (UIColor *)titleLabelColorForDate:(NSDate*)date;
 - (UIImage *)imageForDate:(NSDate *)date;
 - (NSDate *)minimumDateForCalendar;
 - (NSDate *)maximumDateForCalendar;
@@ -413,6 +415,9 @@
     cell.hasEvent = [self hasEventForDate:cell.date];
     cell.dateIsSelected = [self.selectedDates containsObject:cell.date];
     cell.dateIsToday = [cell.date fs_isEqualToDateForDay:_today];
+    cell.titleLabelColor = [self titleLabelColorForDate:cell.date];
+    cell.backgroundColor = [self backgroundColorForDate:cell.date];
+    
     switch (_scope) {
         case FSCalendarScopeMonth: {
             NSDate *month = [_minimumDate.fs_firstDayOfMonth fs_dateByAddingMonths:indexPath.section].fs_dateByIgnoringTimeComponents;
@@ -1437,6 +1442,23 @@
     }
     return _ibEditing && _appearance.fakeSubtitles ? @"test" : nil;
 }
+
+- (UIColor *)backgroundColorForDate:(NSDate *)date
+{
+    if (_dataSource && [_dataSource respondsToSelector:@selector(calendar:backgroundColorForDate:)]) {
+        return [_dataSource calendar:self backgroundColorForDate:date];
+    }
+    return nil;
+}
+
+- (UIColor *)titleLabelColorForDate:(NSDate *)date
+{
+    if (_dataSource && [_dataSource respondsToSelector:@selector(calendar:titleLabelColorForDate:)]) {
+        return [_dataSource calendar:self titleLabelColorForDate:date];
+    }
+    return nil;
+}
+
 
 - (UIImage *)imageForDate:(NSDate *)date
 {

--- a/FSCalendar/FSCalendarCell.h
+++ b/FSCalendar/FSCalendarCell.h
@@ -15,10 +15,12 @@
 @property (weak, nonatomic) FSCalendarAppearance *appearance;
 
 @property (weak, nonatomic) UILabel  *titleLabel;
+@property (weak, nonatomic) UIColor  *titleLabelColor;
 @property (weak, nonatomic) UILabel  *subtitleLabel;
 @property (weak, nonatomic) UIImageView *imageView;
 
 @property (weak, nonatomic) CAShapeLayer *backgroundLayer;
+@property (weak, nonatomic) UIColor *backgroundColor;
 @property (weak, nonatomic) CAShapeLayer *eventLayer;
 
 @property (strong, nonatomic) NSDate   *date;

--- a/FSCalendar/FSCalendarCell.m
+++ b/FSCalendar/FSCalendarCell.m
@@ -159,13 +159,21 @@
     }
     
     _titleLabel.textColor = [self colorForCurrentStateInDictionary:_appearance.titleColors];
+    if (_titleLabelColor != nil) {
+        _titleLabel.textColor = _titleLabelColor;
+    }
     
-    _backgroundLayer.hidden = !self.selected && !self.dateIsToday && !self.dateIsSelected;
+    _backgroundLayer.hidden = !self.selected && !self.dateIsToday && !self.dateIsSelected && (self.backgroundColor == nil);
     if (!_backgroundLayer.hidden) {
         _backgroundLayer.path = _appearance.cellStyle == FSCalendarCellStyleCircle ?
         [UIBezierPath bezierPathWithOvalInRect:_backgroundLayer.bounds].CGPath :
         [UIBezierPath bezierPathWithRect:_backgroundLayer.bounds].CGPath;
-        _backgroundLayer.fillColor = [self colorForCurrentStateInDictionary:_appearance.backgroundColors].CGColor;
+        
+        if (_backgroundColor) {
+            _backgroundLayer.fillColor = _backgroundColor.CGColor;
+        } else {
+            _backgroundLayer.fillColor = [self colorForCurrentStateInDictionary:_appearance.backgroundColors].CGColor;
+        }
     }
     
     _imageView.image = _image;


### PR DESCRIPTION
These changes enables a developer to change the title and background color for each date. 

For example in Swift,

func calendar(calendar: FSCalendar!, backgroundColorForDate date: NSDate!) -> UIColor! {
        return UIColor.purpleColor()
}
    
func calendar(calendar: FSCalendar!, titleLabelColorForDate date: NSDate!) -> UIColor! {
        return UIColor.yellowColor()
}
