### PR TITLE
Add option for sticky month labels in calendar with week scope

### DIFF
--- a/FSCalendar/FSCalendar.h
+++ b/FSCalendar/FSCalendar.h
@@ -88,7 +88,11 @@ IB_DESIGNABLE
 @property (assign, nonatomic) IBInspectable BOOL allowsMultipleSelection;
 @property (assign, nonatomic) IBInspectable BOOL pagingEnabled;
 @property (assign, nonatomic) IBInspectable BOOL scrollEnabled;
+/**
+ Defaults to NO. If YES and the calender is using horizontal scrollDirection and a week scope the month labels will stick while swiping through month. They will only change dependend on the scroll offset of calendar when the month in the calendar view is about to change.
+ */
 @property (assign, nonatomic) IBInspectable BOOL focusOnSingleSelectedDate;
+@property (assign, nonatomic) BOOL useStickyMonthLabelsInWeekScope;
 
 @property (readonly, nonatomic) FSCalendarAppearance *appearance;
 @property (readonly, nonatomic) NSDate *minimumDate;

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -1178,14 +1178,17 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     NSInteger pageStartMonth = [self monthOfDate:pageStartDate];
     NSInteger pageEndMonth = [self monthOfDate:pageEndDate];
     
-    NSInteger monthOffset = pageStartMonth;
+    NSInteger monthOffset = pageStartMonth + 1;
     NSInteger minYear = [self yearOfDate:self.minimumDate];
     NSInteger currentYear = [self yearOfDate:pageStartDate];
     
     // get month value (total number, beginning from minimum date of calendar)
     if (currentYear < minYear) {
-        monthOffset = 0;
-    } else  if (currentYear > minYear) {
+        monthOffset = 1;
+    } else if (currentYear == minYear) {
+        NSInteger minMonth = [self monthOfDate:self.minimumDate];
+        monthOffset = pageStartMonth - minMonth + 1;
+    } else if (currentYear > minYear) {
         NSInteger totalYearDiff = currentYear - minYear;
         // add months for complete years
         if (currentYear - minYear > 1) {
@@ -1194,7 +1197,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
         
         // add months from first year
         NSInteger minMonth = [self monthOfDate:self.minimumDate];
-        monthOffset += 12 - minMonth + 1;
+        monthOffset += 12 - minMonth;
     }
     
     if (pageStartMonth == pageEndMonth) {

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -626,6 +626,11 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
                 break;
             }
         }
+        
+        if (self.useStickyMonthLabelsInWeekScope && self.scope == FSCalendarScopeWeek && self.scrollDirection == FSCalendarScrollDirectionHorizontal) {
+            scrollOffset = [self monthOffsetForScrollOffset:scrollOffset];
+        }
+
         _header.scrollOffset = scrollOffset;
     }
 }
@@ -1159,6 +1164,57 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
 
 #pragma mark - Private methods
 
+- (CGFloat)monthOffsetForScrollOffset:(CGFloat)scrollOffset {
+    NSAssert(self.scope == FSCalendarScopeWeek && self.scrollDirection == FSCalendarScrollDirectionHorizontal && self.useStickyMonthLabelsInWeekScope, @"monthOffset only supported for week scope & horizontal scrolling");
+    
+    CGFloat numberOfWeeks = scrollOffset;
+    static CGFloat numberOfWeekdays = 7;
+    CGFloat numberOfDays = numberOfWeeks * numberOfWeekdays;
+    NSDate *currentMiddleDay = [self dateByAddingDays:numberOfDays toDate:self.minimumDate];
+    
+    NSDate *pageStartDate = [self dateByAddingDays:-4 toDate:currentMiddleDay];
+    NSDate *pageEndDate = [self dateByAddingDays:3 toDate:currentMiddleDay];
+    
+    NSInteger pageStartMonth = [self monthOfDate:pageStartDate];
+    NSInteger pageEndMonth = [self monthOfDate:pageEndDate];
+    
+    NSInteger monthOffset = pageStartMonth;
+    NSInteger minYear = [self yearOfDate:self.minimumDate];
+    NSInteger currentYear = [self yearOfDate:pageStartDate];
+    
+    // get month value (total number, beginning from minimum date of calendar)
+    if (currentYear < minYear) {
+        monthOffset = 0;
+    } else  if (currentYear > minYear) {
+        NSInteger totalYearDiff = currentYear - minYear;
+        // add months for complete years
+        if (currentYear - minYear > 1) {
+            monthOffset += 12 * (totalYearDiff - 1);
+        }
+        
+        // add months from first year
+        NSInteger minMonth = [self monthOfDate:self.minimumDate];
+        monthOffset += 12 - minMonth + 1;
+    }
+    
+    if (pageStartMonth == pageEndMonth) {
+        return monthOffset;
+    }
+    
+    // add month fraction if month changes btw. start and end date of page
+    NSInteger numberOfDaysInStartMonth = [self numberOfDatesInMonthOfDate:pageStartDate];
+    NSInteger pageStartDay = [self dayOfDate:pageStartDate];
+    NSInteger remainingDaysInStartMonth = numberOfDaysInStartMonth - pageStartDay + 1;
+    CGFloat monthFraction = 1 - (remainingDaysInStartMonth / numberOfWeekdays);
+    
+    CGFloat scrollFraction = scrollOffset - floor(scrollOffset);
+    CGFloat weekScrollFraction = scrollFraction * numberOfWeekdays;
+    CGFloat singleDayScrollFraction = (weekScrollFraction - floor(weekScrollFraction)) / numberOfWeekdays;
+    CGFloat totalFraction = monthFraction + singleDayScrollFraction;
+    
+    return monthOffset + totalFraction;
+}
+
 - (void)scrollToDate:(NSDate *)date
 {
     [self scrollToDate:date animated:NO];
@@ -1174,7 +1230,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     _supressEvent = !animated;
     NSDate * targetDate = [self daysFromDate:_minimumDate toDate:date] < 0 ? _minimumDate : date;
     targetDate = [self daysFromDate:_maximumDate toDate:targetDate] > 0 ? _maximumDate : targetDate;
-    NSInteger scrollOffset = 0;
+    CGFloat scrollOffset = 0;
     switch (_scope) {
         case FSCalendarScopeMonth: {
             scrollOffset = [self monthsFromDate:[self beginingOfMonthOfDate:_minimumDate] toDate:targetDate];
@@ -1218,6 +1274,10 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     }
     
     if (_header && !animated) {
+        if (self.useStickyMonthLabelsInWeekScope && self.scope == FSCalendarScopeWeek && self.scrollDirection == FSCalendarScrollDirectionHorizontal) {
+            scrollOffset = [self monthOffsetForScrollOffset:scrollOffset];
+        }
+        
         _header.scrollOffset = scrollOffset;
     }
     _supressEvent = NO;

--- a/FSCalendar/FSCalendarHeader.m
+++ b/FSCalendar/FSCalendarHeader.m
@@ -132,7 +132,14 @@
         }
         case FSCalendarScopeWeek: {
             NSDate *minimumPage = [_calendar beginingOfMonthOfDate:_calendar.minimumDate];
-            NSInteger count = [_calendar weeksFromDate:minimumPage toDate:_calendar.maximumDate] + 1;
+            NSInteger count;
+            
+            if (_calendar.scope == FSCalendarScopeWeek && _calendar.useStickyMonthLabelsInWeekScope) {
+                count = [_calendar monthsFromDate:minimumPage toDate:_calendar.maximumDate] + 1;
+            } else {
+                count = [_calendar weeksFromDate:minimumPage toDate:_calendar.maximumDate] + 1;
+            }
+
             return count + 2;
         }
         default: {
@@ -172,7 +179,14 @@
                 text = nil;
             } else {
                 NSDate *firstPage = [_calendar middleOfWeekFromDate:_calendar.minimumDate];
-                NSDate *date = [_calendar dateByAddingWeeks:indexPath.item-1 toDate:firstPage];
+                NSDate *date = nil;
+                
+                if (_calendar.scope == FSCalendarScopeWeek && _calendar.useStickyMonthLabelsInWeekScope) {
+                    date = [_calendar dateByAddingMonths:indexPath.item-1 toDate:firstPage];
+                } else {
+                    date = [_calendar dateByAddingWeeks:indexPath.item-1 toDate:firstPage];
+                }
+                
                 text = [_calendar.formatter stringFromDate:date];
             }
             break;

--- a/FSCalendar/FSCalendarHeader.m
+++ b/FSCalendar/FSCalendarHeader.m
@@ -135,11 +135,11 @@
             NSInteger count;
             
             if (_calendar.scope == FSCalendarScopeWeek && _calendar.useStickyMonthLabelsInWeekScope) {
-                count = [_calendar monthsFromDate:minimumPage toDate:_calendar.maximumDate] + 1;
+                count = [_calendar monthsFromDate:minimumPage toDate:_calendar.maximumDate] + 3;
             } else {
-                count = [_calendar weeksFromDate:minimumPage toDate:_calendar.maximumDate] + 1;
+                count = [_calendar weeksFromDate:minimumPage toDate:_calendar.maximumDate];
             }
-
+            
             return count + 2;
         }
         default: {
@@ -182,7 +182,7 @@
                 NSDate *date = nil;
                 
                 if (_calendar.scope == FSCalendarScopeWeek && _calendar.useStickyMonthLabelsInWeekScope) {
-                    date = [_calendar dateByAddingMonths:indexPath.item-1 toDate:firstPage];
+                    date = [_calendar dateByAddingMonths:indexPath.item-2 toDate:firstPage];
                 } else {
                     date = [_calendar dateByAddingWeeks:indexPath.item-1 toDate:firstPage];
                 }

--- a/SwiftExample/SwiftExample/ViewController.swift
+++ b/SwiftExample/SwiftExample/ViewController.swift
@@ -17,9 +17,12 @@ class ViewController: UIViewController, FSCalendarDataSource, FSCalendarDelegate
     "20160206","20160306","20160406","20160506","20160606","20160706"]
     override func viewDidLoad() {
         super.viewDidLoad()
-        calendar.scrollDirection = .Vertical
+        calendar.scrollDirection = .Horizontal
+        calendar.scope = .Week
+        calendar.useStickyMonthLabelsInWeekScope = true
         calendar.appearance.caseOptions = [.HeaderUsesUpperCase,.WeekdayUsesUpperCase]
-        calendar.selectDate(calendar.dateWithYear(2015, month: 10, day: 10))
+//        calendar.selectDate(calendar.dateWithYear(2015, month: 10, day: 10))
+        calendar.selectDate(NSDate())
 //        calendar.allowsMultipleSelection = true
         
         // Uncomment this to test month->week and week->month transition
@@ -33,23 +36,23 @@ class ViewController: UIViewController, FSCalendarDataSource, FSCalendarDelegate
         */
 
     }
-    
+    private let monthTimeInterval: NSTimeInterval = 30 * 24 * 60 * 60
 
     func minimumDateForCalendar(calendar: FSCalendar!) -> NSDate! {
-        return calendar.dateWithYear(2015, month: 1, day: 1)
+        return NSDate(timeIntervalSinceNow: -monthTimeInterval)
     }
     
     func maximumDateForCalendar(calendar: FSCalendar!) -> NSDate! {
-        return calendar.dateWithYear(2016, month: 10, day: 31)
+        return NSDate(timeIntervalSinceNow: monthTimeInterval)
     }
-    
+
 
     func calendar(calendar: FSCalendar!, hasEventForDate date: NSDate!) -> Bool {
         return calendar.dayOfDate(date) == 5
     }
 
     func calendarCurrentPageDidChange(calendar: FSCalendar!) {
-        NSLog("change page to \(calendar.stringFromDate(calendar.currentPage))")
+//        NSLog("change page to \(calendar.stringFromDate(calendar.currentPage))")
     }
     
     func calendar(calendar: FSCalendar!, didSelectDate date: NSDate!) {


### PR DESCRIPTION
If calendar is used in a week scope:
The month labels "change" every time you change the week. This can be confusing cause month labels most often will change to the same month (e.g. from `January 2016` to `January 2016`).
When using this option the month label only changes when the month of the date in the current week view changes.