### PR TITLE
prevent calendar direction change to RTL on iOS9+ if iPhone language is right-to-left

### DIFF
--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -234,6 +234,9 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     self.collectionView = collectionView;
     self.collectionViewLayout = collectionViewLayout;
     
+    if ([[[UIDevice currentDevice] systemVersion] compare:@"9.0" options:NSNumericSearch] != NSOrderedAscending)
+        collectionView.semanticContentAttribute = UISemanticContentAttributeSpatial;
+
     UIView *view = [[UIView alloc] initWithFrame:CGRectZero];
     view.backgroundColor = [[UIColor lightGrayColor] colorWithAlphaComponent:0.25];
     [self addSubview:view];


### PR DESCRIPTION
intended to fix issue #211 