### PR TITLE
Correct header and week orientation in case of RTL phone language on iOS9+

### DIFF
--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -234,6 +234,9 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     self.collectionView = collectionView;
     self.collectionViewLayout = collectionViewLayout;
     
+    if ([[[UIDevice currentDevice] systemVersion] compare:@"9.0" options:NSNumericSearch] != NSOrderedAscending)
+        collectionView.semanticContentAttribute = UISemanticContentAttributeSpatial;
+
     UIView *view = [[UIView alloc] initWithFrame:CGRectZero];
     view.backgroundColor = [[UIColor lightGrayColor] colorWithAlphaComponent:0.25];
     [self addSubview:view];

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -234,9 +234,12 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     self.collectionView = collectionView;
     self.collectionViewLayout = collectionViewLayout;
     
-    if ([[[UIDevice currentDevice] systemVersion] compare:@"9.0" options:NSNumericSearch] != NSOrderedAscending)
-        collectionView.semanticContentAttribute = UISemanticContentAttributeSpatial;
-
+#ifdef __IPHONE_9_0
+    if ([self respondsToSelector:@selector(setSemanticContentAttribute:)]) {
+        self.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    }
+#endif
+    
     UIView *view = [[UIView alloc] initWithFrame:CGRectZero];
     view.backgroundColor = [[UIColor lightGrayColor] colorWithAlphaComponent:0.25];
     [self addSubview:view];

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -199,6 +199,11 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     
     UIView *contentView = [[UIView alloc] initWithFrame:CGRectZero];
     contentView.backgroundColor = [UIColor clearColor];
+#ifdef __IPHONE_9_0
+    if ([self respondsToSelector:@selector(setSemanticContentAttribute:)]) {
+        contentView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    }
+#endif
     [self addSubview:contentView];
     self.contentView = contentView;
     
@@ -237,16 +242,27 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
 #ifdef __IPHONE_9_0
     if ([self respondsToSelector:@selector(setSemanticContentAttribute:)]) {
         self.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        collectionView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
     }
 #endif
     
     UIView *view = [[UIView alloc] initWithFrame:CGRectZero];
     view.backgroundColor = [[UIColor lightGrayColor] colorWithAlphaComponent:0.25];
+#ifdef __IPHONE_9_0
+    if ([self respondsToSelector:@selector(setSemanticContentAttribute:)]) {
+        view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    }
+#endif    
     [self addSubview:view];
     self.topBorder = view;
     
     view = [[UIView alloc] initWithFrame:CGRectZero];
     view.backgroundColor = _topBorder.backgroundColor;
+#ifdef __IPHONE_9_0
+    if ([self respondsToSelector:@selector(setSemanticContentAttribute:)]) {
+        view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    }
+#endif   
     [self addSubview:view];
     self.bottomBorder = view;
     
@@ -1389,6 +1405,15 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
             FSCalendarHeader *header = [[FSCalendarHeader alloc] initWithFrame:CGRectZero];
             header.calendar = self;
             header.scrollEnabled = _scrollEnabled;
+
+#ifdef __IPHONE_9_0
+            if ([self respondsToSelector:@selector(setSemanticContentAttribute:)]) {
+                header.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+            }
+#endif
+
+            
+            
             [_contentView addSubview:header];
             self.header = header;
             
@@ -1399,6 +1424,11 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
                 FSCalendarHeaderTouchDeliver *deliver = [[FSCalendarHeaderTouchDeliver alloc] initWithFrame:CGRectZero];
                 deliver.header = _header;
                 deliver.calendar = self;
+#ifdef __IPHONE_9_0
+                if ([self respondsToSelector:@selector(setSemanticContentAttribute:)]) {
+                    deliver.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+                }
+#endif
                 [_contentView addSubview:deliver];
                 self.deliver = deliver;
             }

--- a/FSCalendar/FSCalendarHeader.m
+++ b/FSCalendar/FSCalendarHeader.m
@@ -65,6 +65,11 @@
     collectionView.delegate = self;
     collectionView.showsHorizontalScrollIndicator = NO;
     collectionView.showsVerticalScrollIndicator = NO;
+#ifdef __IPHONE_9_0
+    if ([self respondsToSelector:@selector(setSemanticContentAttribute:)]) {
+        collectionView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    }
+#endif
     [self addSubview:collectionView];
     [collectionView registerClass:[FSCalendarHeaderCell class] forCellWithReuseIdentifier:@"cell"];
     self.collectionView = collectionView;

--- a/FSCalendar/FSCalendarStickyHeader.m
+++ b/FSCalendar/FSCalendarStickyHeader.m
@@ -57,6 +57,13 @@
             [weekdayLabels addObject:label];
         }
         self.weekdayLabels = weekdayLabels.copy;
+        
+#ifdef __IPHONE_9_0
+        if ([self respondsToSelector:@selector(setSemanticContentAttribute:)]) {
+            self.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        }
+#endif
+
     }
     return self;
 }


### PR DESCRIPTION
I've added more `_view_.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;` calls to other views in month view. Hope haven't missed something or overdone it. Please check.
